### PR TITLE
Adding refresh token to the AADToken structure

### DIFF
--- a/src/main/java/com/microsoft/azure/datalake/store/oauth2/AzureADAuthenticator.java
+++ b/src/main/java/com/microsoft/azure/datalake/store/oauth2/AzureADAuthenticator.java
@@ -144,6 +144,7 @@ public class AzureADAuthenticator {
                         fieldValue = jp.getText();
 
                         if (fieldName.equals("access_token")) token.accessToken = fieldValue;
+                        if (fieldName.equals("refresh_token")) token.refreshToken = fieldValue;
                         if (fieldName.equals("expires_in")) expiryPeriod = Integer.parseInt(fieldValue);
                     }
                     jp.nextToken();

--- a/src/main/java/com/microsoft/azure/datalake/store/oauth2/AzureADToken.java
+++ b/src/main/java/com/microsoft/azure/datalake/store/oauth2/AzureADToken.java
@@ -14,5 +14,6 @@ import java.util.Date;
  */
 public class AzureADToken {
     public String accessToken;
+    public String refreshToken;
     public Date expiry;
 }


### PR DESCRIPTION
The current AADToken structure does not support refresh tokens. Since the token expires in 1 hour, any activity on ADLS that exceeds 1 hours fails with 401 error. There are two options:

1. Extend the expiry in AD
2. Make the refresh_token accessible so that the client can refresh the token which gives 14 days before expiration

This fix is to make the refresh token accessible