### PR TITLE
Upgrade to newer release of the maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
+        <version>3.0.1</version>
         <configuration>
           <quiet>true</quiet>  <!-- only show warnings and errors during build -->
         </configuration>


### PR DESCRIPTION
Building the SDK under JDK 11 fails due to the outdated version of maven-javadoc-plugin specified in the Maven pom file. Version 2.10.4 was released in June 2016, and is not supported under JDK 11. I have changed this to instead use 3.0.1, which was released in May 2018. SDK compilation now succeeds under JDK 11 (as well as earlier JDK releases).