### PR TITLE
Add option to allocate buffer for ADLFileInputStream using off heap memory

### DIFF
--- a/src/main/java/com/microsoft/azure/datalake/store/ADLStoreClient.java
+++ b/src/main/java/com/microsoft/azure/datalake/store/ADLStoreClient.java
@@ -43,6 +43,7 @@ public class ADLStoreClient {
     private String tiHeader = null;
     private String proto = "https";
     private boolean enableRemoteExceptions = false;
+    private boolean useOffHeapMemory = Boolean.getBoolean(ADLStoreOptions.USE_OFF_HEAP_MEMORY_KEY);
     private String pathPrefix = null;
     private int readAheadQueueDepth = -1;  // no preference set by caller, use default in ADLFileInputStream
     volatile boolean disableReadAheads = false;
@@ -1002,6 +1003,7 @@ public class ADLStoreClient {
         if (o.getReadAheadQueueDepth() >= 0 ) this.readAheadQueueDepth = o.getReadAheadQueueDepth();
         if (o.getDefaultTimeout() > 0) this.timeout = o.getDefaultTimeout();
         this.alterCipherSuits = o.shouldAlterCipherSuits();
+        this.useOffHeapMemory = o.isUsingOffHeapMemory();
     }
 
 
@@ -1217,5 +1219,12 @@ public class ADLStoreClient {
         }
     }
 
+    boolean isUsingOffHeapMemory() {
+        return useOffHeapMemory;
+    }
+
+    public void setUseOffHeapMemory(boolean useOffHeapMemory) {
+        this.useOffHeapMemory = useOffHeapMemory;
+    }
 
 }

--- a/src/main/java/com/microsoft/azure/datalake/store/ADLStoreOptions.java
+++ b/src/main/java/com/microsoft/azure/datalake/store/ADLStoreOptions.java
@@ -11,6 +11,8 @@ package com.microsoft.azure.datalake.store;
  */
 public class ADLStoreOptions {
 
+    public static final String USE_OFF_HEAP_MEMORY_KEY = "com.microsoft.azure.datalake.store.use_off_heap_memory";
+
     private String userAgentSuffix = null;
     private boolean insecureTransport = false;
     private boolean enableRemoteExceptions = false;
@@ -18,6 +20,7 @@ public class ADLStoreOptions {
     private int readAheadQueueDepth = -1;  // no preference set by caller, use default in ADLFileInputStream
     private int defaultTimeout = -1;
     private boolean alterCipherSuits = true;
+    private boolean useOffHeapMemory = Boolean.getBoolean(USE_OFF_HEAP_MEMORY_KEY);
 
     public ADLStoreOptions() {
     }
@@ -168,5 +171,13 @@ public class ADLStoreOptions {
 
     boolean shouldAlterCipherSuits() {
         return this.alterCipherSuits;
+    }
+
+    boolean isUsingOffHeapMemory() {
+        return this.useOffHeapMemory;
+    }
+
+    public void setUseOffHeapMemory(boolean useOffHeapMemory) {
+        this.useOffHeapMemory = useOffHeapMemory;
     }
 }

--- a/src/main/java/com/microsoft/azure/datalake/store/ReadBufferWorker.java
+++ b/src/main/java/com/microsoft/azure/datalake/store/ReadBufferWorker.java
@@ -45,7 +45,7 @@ class ReadBufferWorker implements Runnable {
             if (buffer != null) {
                 try {
                     // do the actual read, from the file.
-                    int bytesRead = buffer.file.readRemote(buffer.offset, buffer.buffer, 0, buffer.requestedLength, true);
+                    int bytesRead = buffer.file.readRemote(buffer.offset, buffer.buffer, null, 0, buffer.requestedLength, true);
                     bufferManager.doneReading(buffer, ReadBufferStatus.AVAILABLE, bytesRead);  // post result back to ReadBufferManager
                 } catch (Exception ex) {
                     bufferManager.doneReading(buffer, ReadBufferStatus.READ_FAILED, 0);


### PR DESCRIPTION
Buffering mode can be set using the system property com.microsoft.azure.datalake.store.use_off_heap_memory

Or by explicitly setting it on ADLStoreOptions