### PR TITLE
Upgrading wildfly-openssl version to 1.0.7.Final to fix NPE 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <dependency>
       <groupId>org.wildfly.openssl</groupId>
       <artifactId>wildfly-openssl</artifactId>
-      <version>1.0.0.CR5</version>
+      <version>1.0.7.Final</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
Wildfly-openssl will fail with a NPE if using OpenSSL 1.1.1

This fix was introduced in v1.0.7.Final