### PR TITLE
Fix the setters in adlstoreoptions, Fetch MSI token directly from AAD…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 # Changes to the SDK
+### Version 2.3.9
+1. Fix the setters in adlstoreoptions to return instance of adlstoreoptions
+2. Fetch MSI token directly from AAD if first fetch from MSI cache is the same expiring token.
+3. Fix getcontentsummary to do enumerates using continuation token
 
 ### Version 2.3.8
 1. Add logging for token acquisition.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-data-lake-store-sdk</artifactId>
-  <version>2.3.8</version>
+  <version>2.3.9</version>
   <packaging>jar</packaging>
   <name>Azure Data Lake Store - Java client SDK</name>
   <url>https://azure.microsoft.com/en-us/services/data-lake-store</url>

--- a/src/main/java/com/microsoft/azure/datalake/store/ADLStoreClient.java
+++ b/src/main/java/com/microsoft/azure/datalake/store/ADLStoreClient.java
@@ -621,7 +621,7 @@ public class ADLStoreClient {
         return deList;
     }
 
-    private DirectoryEntryListWithContinuationToken enumerateDirectoryInternal(String path,
+    DirectoryEntryListWithContinuationToken enumerateDirectoryInternal(String path,
                                                             int maxEntriesToRetrieve,
                                                             String startAfter,
                                                             String endBefore,

--- a/src/main/java/com/microsoft/azure/datalake/store/ADLStoreOptions.java
+++ b/src/main/java/com/microsoft/azure/datalake/store/ADLStoreOptions.java
@@ -174,26 +174,33 @@ public class ADLStoreOptions {
      *
      * @param alterCipherSuits true if the cipher suite alteration is required.
      */
-    public void alterCipherSuits(boolean alterCipherSuits) {
+    public ADLStoreOptions alterCipherSuits(boolean alterCipherSuits) {
         this.alterCipherSuits = alterCipherSuits;
+        return this;
     }
 
     boolean shouldAlterCipherSuits() {
         return this.alterCipherSuits;
     }
 
-    public void setSSLChannelMode(String sslChannelMode) {
+    /**
+     * Set SSL Channel mode
+     * @param sslChannelMode  SSL Channel mdoe to set
+     * @return
+     */
+    public ADLStoreOptions setSSLChannelMode(String sslChannelMode) {
         SSLChannelMode[] sslChannelModes = SSLChannelMode.values();
         for(SSLChannelMode mode : sslChannelModes)
         {
             if (sslChannelMode.equalsIgnoreCase(mode.name()))
             {
                 this.sslChannelMode = mode;
-                return;
+                return this;
             }
         }
 
       this.sslChannelMode = SSLChannelMode.Default;
+        return this;
     }
 
     SSLChannelMode getSSLChannelMode() {
@@ -207,10 +214,11 @@ public class ADLStoreOptions {
     /**
      * sets the number of retries for exponential retry policy used by methods in ADLStoreClient objects
      * @param maxRetries number of retries for exponential retry policy
-     * @return {@code this}
+     *
      */
-    public void setMaxRetries(int maxRetries) {
+    public ADLStoreOptions setMaxRetries(int maxRetries) {
         this.maxRetries = maxRetries;
+        return this;
     }
 
     int getExponentialRetryInterval() {
@@ -220,10 +228,11 @@ public class ADLStoreOptions {
     /**
      * sets the retry interval for exponential retry policy used by methods in ADLStoreClient objects
      * @param exponentialRetryInterval retry interval for exponential retry policy in milliseconds
-     * @return {@code this}
+     *
      */
-    public void setExponentialRetryInterval(int exponentialRetryInterval) {
+    public ADLStoreOptions setExponentialRetryInterval(int exponentialRetryInterval) {
         this.exponentialRetryInterval = exponentialRetryInterval;
+        return this;
     }
 
     int getExponentialFactor() {
@@ -233,14 +242,21 @@ public class ADLStoreOptions {
     /**
      * sets the factor of backoff for exponential retry policy used by methods in ADLStoreClient objects
      * @param exponentialFactor retry backoff factor for exponential retry policy
-     * @return {@code this}
+     *
      */
-    public void setExponentialFactor(int exponentialFactor) {
+    public ADLStoreOptions setExponentialFactor(int exponentialFactor) {
         this.exponentialFactor = exponentialFactor;
+        return this;
     }
 
-    public void setEnableConditionalCreate(boolean enableConditionalCreate) {
+    /**
+     * Config to enable create only if conditional delete has passed
+     * @param enableConditionalCreate boolean value to set
+     * @return
+     */
+    public ADLStoreOptions setEnableConditionalCreate(boolean enableConditionalCreate) {
         this.enableConditionalCreate = enableConditionalCreate;
+        return this;
     }
 
     boolean shouldEnableConditionalCreate(){

--- a/src/main/java/com/microsoft/azure/datalake/store/oauth2/AccessTokenProvider.java
+++ b/src/main/java/com/microsoft/azure/datalake/store/oauth2/AccessTokenProvider.java
@@ -58,7 +58,7 @@ public abstract class AccessTokenProvider {
      *
      * @return true if the token is expiring in next 5 minutes
      */
-    private boolean isTokenAboutToExpire() {
+    protected boolean isTokenAboutToExpire() {
         if (token==null) {
             log.debug("AADToken: no token. Returning expiring=true");
             return true;   // no token should have same response as expired token
@@ -67,11 +67,11 @@ public abstract class AccessTokenProvider {
             log.debug("AADToken: no token expiry set. Returning expiring=true");
             return true; // if don't know expiry then assume expired (should not happen with a correctly implemented token)
         }
-        boolean expiring = false;
-        long approximatelyNow = System.currentTimeMillis() + FIVE_MINUTES;   // allow 5 minutes for clock skew
-        if (token.expiry.getTime() < approximatelyNow) expiring = true;
+        long offset = FIVE_MINUTES;
+        long approximatelyNow = System.currentTimeMillis() + offset;   // allow x minutes for clock skew, depends on type of provider
+        boolean expiring = (token.expiry.getTime() < approximatelyNow);
         if (expiring) {
-            log.debug("AADToken: token expiring: " + token.expiry.toString() + " : Five-minute window: " + new Date(approximatelyNow).toString());
+            log.debug("AADToken: token expiring: " + token.expiry.toString() + " : " + offset + " milliseconds window: " + new Date(approximatelyNow).toString());
         }
 
         return expiring;

--- a/src/main/java/com/microsoft/azure/datalake/store/oauth2/MsiTokenProvider.java
+++ b/src/main/java/com/microsoft/azure/datalake/store/oauth2/MsiTokenProvider.java
@@ -20,7 +20,7 @@ public class MsiTokenProvider extends AccessTokenProvider {
     private final int localPort = -1;
     private final String tenantGuid;
     private final String clientId;
-
+    private long tokenFetchTime =-1;
     /**
      * Constructs a token provider that fetches tokens from the MSI token-service running on an Azure IaaS VM. This
      * only works on an Azure VM with the MSI extansion enabled.
@@ -63,10 +63,35 @@ public class MsiTokenProvider extends AccessTokenProvider {
         this.clientId = clientId;
     }
 
+    /**
+     * Checks if the token is about to expire as per base expiry logic. Otherwise try to expire every 1 hour
+     *
+     *
+     * @return true if the token is expiring in next 5 minutes
+     */
+    @Override
+    protected boolean isTokenAboutToExpire() {
+        if( super.isTokenAboutToExpire()){
+            return true;
+        }
+        if (tokenFetchTime == -1){
+            return true;
+        }
+        long offset = ONE_HOUR;
+        if ((tokenFetchTime +offset) < System.currentTimeMillis()) {
+            log.debug("MSIToken: token renewing : " + offset + " milliseconds window");
+            return true;
+        }
+
+        return false;
+    }
+
     @Override
     protected AzureADToken refreshToken() throws IOException {
-        log.debug("AADToken: refreshing token from MSI");
-        AzureADToken token =  AzureADAuthenticator.getTokenFromMsi(tenantGuid, clientId, false);
-        return token;
+        log.debug("AADToken: refreshing token from MSI with expiry");
+        AzureADToken newToken =  AzureADAuthenticator.getTokenFromMsi(tenantGuid, clientId, false);
+        tokenFetchTime=System.currentTimeMillis();
+        return newToken;
     }
+    private static final long ONE_HOUR = 3600 * 1000; // 5 minutes in milliseconds
 }

--- a/src/test/java/com/contoso/liveservicetests/TestFileSdk.java
+++ b/src/test/java/com/contoso/liveservicetests/TestFileSdk.java
@@ -43,9 +43,16 @@ public class TestFileSdk {
     @BeforeClass
     public static void setup() throws IOException {
         Properties prop = HelperUtils.getProperties();
-        AzureADToken aadToken = AzureADAuthenticator.getTokenUsingClientCreds(prop.getProperty("OAuth2TokenUrl"),
-                prop.getProperty("ClientId"),
-                prop.getProperty("ClientSecret") );
+        boolean useMsiForAuth = Boolean.parseBoolean(prop.getProperty("useMsi","false"));
+        AzureADToken aadToken;
+        if(useMsiForAuth){
+            aadToken = AzureADAuthenticator.getTokenFromMsi(prop.getProperty("OAuth2TokenUrl"), prop.getProperty("ClientId"),false);
+        }
+        else {
+            aadToken = AzureADAuthenticator.getTokenUsingClientCreds(prop.getProperty("OAuth2TokenUrl"),
+                    prop.getProperty("ClientId"),
+                    prop.getProperty("ClientSecret"));
+        }
         UUID guid = UUID.randomUUID();
         directory = "/" + prop.getProperty("dirName") + "/" + UUID.randomUUID();
         String account = prop.getProperty("StoreAcct") + ".azuredatalakestore.net";
@@ -924,7 +931,6 @@ public class TestFileSdk {
 
 
             List<DirectoryEntry> list;
-
             // non-existent directory
             try {
                 list = client.enumerateDirectory(dirname);


### PR DESCRIPTION
### Version 2.3.9
1. Fix the setters in adlstoreoptions to return instance of adlstoreoptions
2. Fetch MSI token directly from AAD if first fetch from MSI cache is the same expiring token.
3. Fix getcontentsummary to do enumerates using continuation token