### PR TITLE
Release 2.3.10. Update log4j and junit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 # Changes to the SDK
+### Version 2.3.10
+1. Update og4j to mitigate CVE-2021-44228
+
 ### Version 2.3.9
 1. Fix the setters in adlstoreoptions to return instance of adlstoreoptions
 2. Fetch MSI token directly from AAD if first fetch from MSI cache is the same expiring token.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes to the SDK
 ### Version 2.3.10
-1. Update og4j to mitigate CVE-2021-44228
+1. Update log4j to mitigate CVE-2021-44228. Also update junit.
 
 ### Version 2.3.9
 1. Fix the setters in adlstoreoptions to return instance of adlstoreoptions

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-data-lake-store-sdk</artifactId>
-  <version>2.3.9</version>
+  <version>2.3.10</version>
   <packaging>jar</packaging>
   <name>Azure Data Lake Store - Java client SDK</name>
   <url>https://azure.microsoft.com/en-us/services/data-lake-store</url>
@@ -179,13 +179,13 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.8.2</version>
+      <version>2.15.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.8.2</version>
+      <version>2.15.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.8.2</version>
+      <version>2.15.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Update log4j to mitigate CVE-2021-44228. 

Also update junit.